### PR TITLE
#9 Minimize to systray

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from gi.repository import Gtk
+
+class Callbacks:
+
+	def exit_application(self, widget):
+		Gtk.main_quit()
+
+	def about_application(self, widget):
+		print "developers: { rochapaulo, oliveirasevandro }"

--- a/config.json
+++ b/config.json
@@ -3,6 +3,30 @@
 	"toggleButtonVPN_02":"VPN 1",
 	"toggleButtonConnectTunel":">",
 	"buttonRepository":"Repository",
+	"systray-menu":[
+		{
+			"label": "About",
+			"actions":[
+				{
+					"name":"activate",
+					"module":"callbacks",
+					"className":"Callbacks",
+					"command":"about_application"
+				}
+			]
+		},
+		{
+			"label": "Exit",
+			"actions":[
+				{
+					"name":"activate",
+					"module":"callbacks",
+					"className":"Callbacks",
+					"command":"exit_application"
+				}
+			]
+		}
+	],
 	"tunnelList":[
 		{
 			"label":"Tunnel #00000",

--- a/configLoader.py
+++ b/configLoader.py
@@ -5,6 +5,8 @@ import json
 
 class ConfigLoader:
 
+	CONFIGURATION_FILE = "config.json"
+
 	widgets = [
 		"toggleButtonVPN_01",
 		"toggleButtonVPN_02",
@@ -12,15 +14,8 @@ class ConfigLoader:
 		"buttonRepository"
 	]
 
-	preferences = None
-
 	@staticmethod
-	def configure(builder, filePath):
-		print "Loading configuration from file [" + filePath + "]..."
-
-		with open(filePath) as config_file:
-			ConfigLoader.preferences = json.loads(config_file.read())
-
+	def configure(builder):
 		for widget_id in ConfigLoader.widgets:
 			widget = builder.get_object(widget_id)
 			widget.set_label(ConfigLoader.preferences[widget_id])
@@ -35,3 +30,10 @@ class ConfigLoader:
 		tunnelSelectCombo.pack_start(renderer_text, True)
 		tunnelSelectCombo.add_attribute(renderer_text, "text", 0)
 
+
+	def loadPreferences(filePath):
+		print "Loading preferences"
+		with open(filePath) as config_file:
+			return json.loads(config_file.read())
+
+	preferences = loadPreferences(CONFIGURATION_FILE)

--- a/wuohoy.py
+++ b/wuohoy.py
@@ -6,20 +6,50 @@ from widgetHandlers import WidgetHandlers
 
 class Wuohoy:
 
-	def __init__(self):
-
+	def activate(self, widget, data=None):
 		builder = Gtk.Builder()
 		builder.add_from_file("gui.glade")
 		builder.connect_signals(WidgetHandlers(builder));
 
-		ConfigLoader.configure(builder, "config.json")
-
+		ConfigLoader.configure(builder)
 		self.window = builder.get_object("MainWindow")
-		self.window.connect("destroy", Gtk.main_quit);
-		
+		self.window.connect('destroy', self.hide)
 		self.window.show_all()
+
+	def hide(self, widget, data=None):
+		self.window.hide()
+
+	def staticon_right_click(self, icon, button, time):
+		self.menu = Gtk.Menu()
+		for item in ConfigLoader.preferences['systray-menu']:
+			self.menuItem = Gtk.MenuItem()
+			self.menuItem.set_label(item['label'])
+
+			for action in item['actions']:
+				module = __import__(action['module'])
+				klazz = getattr(module, action['className'])
+
+				function = getattr(klazz(), action['command'])
+				self.menuItem.connect(action['name'], function)
+
+			self.menu.append(self.menuItem)
+
+		self.menu.show_all()
+
+		def pos(menu, icon):
+			return (Gtk.StatusIcon.position_menu(menu, icon))
+
+		self.menu.popup(None, None, pos, self.staticon, button, time)
+
+
+	def __init__(self):
+		self.staticon = Gtk.StatusIcon()
+		self.staticon.set_from_stock(Gtk.STOCK_EXECUTE)
+		self.staticon.connect('activate', self.activate)
+		self.staticon.connect('popup-menu', self.staticon_right_click)
+		self.staticon.set_visible(True)
+		self.window = None
 
 if __name__ == "__main__":
 	hwg = Wuohoy()
 	Gtk.main()
-


### PR DESCRIPTION
1 - now when the application is closed, it will be minimized to "systray"
2 - rightClick functionality to staticon
3 - the staticon menu was implemented like a plugin.... (We can plug new funcs just adding an entry on systray-menu inside a config.json file

```json
{
    "label":"menu_item_label",
    "actions": [ {
        "name":"action_name",
        "module": "python_module_name",
        "className": "class_name",
        "command": "method_called_from_class"
    } ]
},
...
```

* callbacks.py is a module that contains default operations for systray-menu (close, about...)